### PR TITLE
A PlayOnlineViewer installation folder was set.

### DIFF
--- a/xiloader/defines.h
+++ b/xiloader/defines.h
@@ -48,7 +48,8 @@ This file is part of DarkStar-server source code.
 #define POLFUNC_INET_MUTEX      0x032F
 #define POLFUNC_REGISTRY_LANG   0x03C5
 #define POLFUNC_FFXI_LANG       0x01A4
-#define POLFUNC_INTERFACE_LANG  0x016F
+#define POLFUNC_REGISTRY_KEY    0x016F
+#define POLFUNC_INSTALL_FOLDER  0x007D
 
 namespace xiloader
 {
@@ -71,14 +72,6 @@ namespace xiloader
     /* FFXi COM Object Definitions */
     const CLSID CLSID_FFXiEntry = { 0x989D790D, 0x6236, 0x11D4, { 0x80, 0xE9, 0x00, 0x10, 0x5A, 0x81, 0xE8, 0x90 } };
     const IID IID_IFFXiEntry = { 0x989D790C, 0x6236, 0x11D4, { 0x80, 0xE9, 0x00, 0x10, 0x5A, 0x81, 0xE8, 0x90 } };
-
-    /* PlayOnline Registry Keys */
-    const char RegistryKeys[3][255] =
-    {
-        { "SOFTWARE\\PlayOnline" },
-        { "SOFTWARE\\PlayOnlineUS" },
-        { "SOFTWARE\\PlayOnlineEU" }
-    };
 
     /* PlayOnline Language Enumeration */
     enum Language

--- a/xiloader/functions.h
+++ b/xiloader/functions.h
@@ -68,13 +68,33 @@ namespace xiloader
         static DWORD FindPattern(const char* moduleName, const unsigned char* lpPattern, const char* pszMask);
 
         /**
+         * @brief Obtains the PlayOnline registry key.
+         *  "SOFTWARE\PlayOnlineXX"
+         *
+         * @param lang      The language id the loader was started with.
+         *
+         * @return registry pathname.
+         */
+        static const char* GetRegistryPlayOnlineKey(int lang);
+
+        /**
          * @brief Obtains the PlayOnline language id from the system registry.
          *
          * @param lang      The language id the loader was started with.
          *
          * @return The language id from the registry, 1 otherwise.
          */
-        static unsigned int GetRegistryLanguage(int lang);
+        static int GetRegistryPlayOnlineLanguage(int lang);
+
+        /**
+         * @brief Obtains the PlayOnlineViewer folder from the system registry.
+         *  "C:\Program Files\PlayOnline\PlayOnlineViewer"
+         *
+         * @param lang      The language id the loader was started with.
+         *
+         * @return installation folder path.
+         */
+        static const char* GetRegistryPlayOnlineInstallFolder(int lang);
     };
 
 }; // namespace xiloader

--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -354,8 +354,9 @@ int __cdecl main(int argc, char* argv[])
 
                 /* Invoke the setup functions for polcore.. */
                 lpCommandTable[POLFUNC_REGISTRY_LANG](g_Language);
-                lpCommandTable[POLFUNC_FFXI_LANG](xiloader::functions::GetRegistryLanguage(g_Language));
-                lpCommandTable[POLFUNC_INTERFACE_LANG](xiloader::RegistryKeys[g_Language]);
+                lpCommandTable[POLFUNC_FFXI_LANG](xiloader::functions::GetRegistryPlayOnlineLanguage(g_Language));
+                lpCommandTable[POLFUNC_REGISTRY_KEY](xiloader::functions::GetRegistryPlayOnlineKey(g_Language));
+                lpCommandTable[POLFUNC_INSTALL_FOLDER](xiloader::functions::GetRegistryPlayOnlineInstallFolder(g_Language));
                 lpCommandTable[POLFUNC_INET_MUTEX]();
 
                 /* Attempt to create FFXi instance..*/


### PR DESCRIPTION
- A PlayOnlineViewer installation folder was set.
  You don't have to copy folder "PlayOnlineViewer/data" to "FINAL FANTASY XI/data"
