### PR TITLE
Changed login prompt to use cin instead of _getch

### DIFF
--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -241,26 +241,7 @@ namespace xiloader
                 std::cout << "\nUsername: ";
                 std::cin >> g_Username;
                 std::cout << "Password: ";
-                g_Password.clear();
-
-                /* Read in each char and instead of displaying it. display a "*" */
-                char ch;
-                while ((ch = static_cast<char>(_getch())) != '\r')
-                {
-                    if (ch == '\b')
-                    {
-                        if (g_Password.size())
-                        {
-                            g_Password.pop_back();
-                            std::cout << "\b \b";
-                        }
-                    }
-                    else
-                    {
-                        g_Password.push_back(ch);
-                        std::cout << '*';
-                    }
-                }
+                std::cin >> g_Password;
                 std::cout << std::endl;
 
                 sendBuffer[0x20] = 0x10;


### PR DESCRIPTION
Fixes #20 (double/null character at login prompt) at the cost of having no password masking.